### PR TITLE
Hooks for status code and on unauthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+Changelog
+=========
+
+## 2.0.0
+
+### Remove Strict
+
+Removed the strict option, and replaced with `onUnauthenticated` hook.
+
+This update allows the calling application to implement additional functionality
+when a request is found to be unauthenticated.  The examples shows:
+
+- logging
+- different status code
+- reimplement strict
+
+## 1.0.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -90,14 +90,9 @@ function (req, data, callback)
 
 ### strict
 
-Optional; `Boolean` (default: `true`)
+*** NO LONGER SUPPORTED ***
 
-By default, the middleware will end the request with a 401 HTTP error
-when authentication fails. You may want to handle this differently, in which case you should set this option to `false`.
-
-The next request handler will then be called, and the req will have:
-
-`req.g2o.authenticated = false`
+If you want to implement not strict logic see: [onUnauthenticated](#onUnauthenticated).
 
 ### dataHeader
 
@@ -172,37 +167,49 @@ app.use(g2o({
 }));
 ```
 
-### unauthenticatedStatusCode
-
-Optional; `Integer` (default: 401)
-
-If provided, the status code will be used as the response status code for when the authentication fails.
-
 ### onUnauthenticated
 
-Optional; `Function` (default: noop)
+Optional; `Function` (default: 
+
+```javascript
+function (req, res, next) {
+    var statusCode = 401;
+    if (typeof res.status === "function") {
+        // Express has a status() helper function
+        res.status(statusCode);
+    } else {
+        res.statusCode = statusCode;
+    }
+    res.end();
+}
+```
+
+)
 
 If provided, the function will be called after all checks have been completed and found to be unauthenticated.
 An unauthenticated g2o data will have a message property, that is the failure reason. The signature should be:
 
 ```javascript
-function (req, callback)
+function (req, res, next)
 ```
 
-An example implementation that logs out the failed request:
+An example implementation that:
+
+- logs out the failed request
+- uses a different status code
+- only fails request if strict
 
 ```javascript
 var g2o = require("akamai-g2o");
 var app = require("express")();
-var strict = true;
+var strict = true; // strict controlled outside, but maybe some config.
 
 app.use(g2o({
    key: {
     "nonce1": "s3cr3tk3y",
     "nonce2": "s3cr3tk3y2",
    },
-   strict: strict
-   onUnauthenticated: function (req, callback) {
+   onUnauthenticated: function (req, res, next) {
       var g2oResponse = Object.assign(
          {},
          {
@@ -213,7 +220,14 @@ app.use(g2o({
          },
          req.g2o
       );
-      console.log('g2o unauthenticated', g2oResponse);
+
+      console.log('g2o unauthenticated', g2oResponse); // logging
+
+      if (strict) { // only fail request if strict
+         res.status(407).end(); // different status code
+      } else {
+         next();
+      }
    }
 }));
 ```

--- a/README.md
+++ b/README.md
@@ -172,6 +172,52 @@ app.use(g2o({
 }));
 ```
 
+### unauthenticatedStatusCode
+
+Optional; `Integer` (default: 401)
+
+If provided, the status code will be used as the response status code for when the authentication fails.
+
+### onUnauthenticated
+
+Optional; `Function` (default: noop)
+
+If provided, the function will be called after all checks have been completed and found to be unauthenticated.
+An unauthenticated g2o data will have a message property, that is the failure reason. The signature should be:
+
+```javascript
+function (req, callback)
+```
+
+An example implementation that logs out the failed request:
+
+```javascript
+var g2o = require("akamai-g2o");
+var app = require("express")();
+var strict = true;
+
+app.use(g2o({
+   key: {
+    "nonce1": "s3cr3tk3y",
+    "nonce2": "s3cr3tk3y2",
+   },
+   strict: strict
+   onUnauthenticated: function (req, callback) {
+      var g2oResponse = Object.assign(
+         {},
+         {
+            strict: strict,
+            clientIp: req.ip, // for if there are no g2o header fallback to server known ip.
+            forwardAddresses: req.forwardAddresses,
+            uri: req.originalUrl, // note this is for express 4.0, else it is req.url
+         },
+         req.g2o
+      );
+      console.log('g2o unauthenticated', g2oResponse);
+   }
+}));
+```
+
 ## Data object description
 
 Ghost is required to send a header containing authentication information which is used to generate the signature. This library parses

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -19,19 +19,26 @@ module.exports = function (options) {
                 req.g2o.message = error.message;
             }
             if (options.strict && !req.g2o.authenticated) {
-                if (typeof res.status === "function") {
-                    // Express has a status() helper function
-                    res.status(401);
-                } else {
-                    res.statusCode = 401;
-                }
-                res.end();
+                options.onUnauthenticated(
+                    req,
+                    requestUnauthenticated.bind(null, options, res)
+                );
             } else {
                 next();
             }
         });
     };
 };
+
+function requestUnauthenticated(options, res) {
+    if (typeof res.status === "function") {
+        // Express has a status() helper function
+        res.status(options.unauthenticatedStatusCode);
+    } else {
+        res.statusCode = options.unauthenticatedStatusCode;
+    }
+    res.end();
+}
 
 function authenticateRequest(options, req, callback) {
     var dataHeader = options.dataHeader.toLowerCase();
@@ -107,14 +114,10 @@ function sanitizeOptions(options) {
         timeWindow: 30,
         dataHeader: "X-Akamai-G2O-Auth-Data",
         signHeader: "X-Akamai-G2O-Auth-Sign",
-        signString: function (req) {
-            if (req.originalUrl) {
-                var bits = require("url").parse(req.originalUrl);
-                return bits.path;
-            }
-            return req.url;
-        },
-        extraCheck: null
+        signString: defaultSignStringFunction,
+        extraCheck: null,
+        unauthenticatedStatusCode: 401,
+        onUnauthenticated: defaultOnUnauthenticatedFunction,
     }, options);
 
     // make sure the key option is a function even if the user
@@ -135,4 +138,23 @@ function sanitizeOptions(options) {
     }
 
     return options;
+}
+
+function defaultSignStringFunction(req) {
+    if (req.originalUrl) {
+        var bits = require("url").parse(req.originalUrl);
+        return bits.path;
+    }
+    return req.url;
+}
+
+function defaultKeyFunction(req, data, callback) {
+    if (data.nonce in this) {
+        return callback(null, this[data.nonce]);
+    }
+    callback(new Error("unknown nonce"));
+}
+
+function defaultOnUnauthenticatedFunction(req, callback) {
+    return callback();
 }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -18,27 +18,14 @@ module.exports = function (options) {
                 req.g2o.authenticated = false;
                 req.g2o.message = error.message;
             }
-            if (options.strict && !req.g2o.authenticated) {
-                options.onUnauthenticated(
-                    req,
-                    requestUnauthenticated.bind(null, options, res)
-                );
+            if (!req.g2o.authenticated) {
+                options.onUnauthenticated(req, res, next);
             } else {
                 next();
             }
         });
     };
 };
-
-function requestUnauthenticated(options, res) {
-    if (typeof res.status === "function") {
-        // Express has a status() helper function
-        res.status(options.unauthenticatedStatusCode);
-    } else {
-        res.statusCode = options.unauthenticatedStatusCode;
-    }
-    res.end();
-}
 
 function authenticateRequest(options, req, callback) {
     var dataHeader = options.dataHeader.toLowerCase();
@@ -109,14 +96,12 @@ function sanitizeOptions(options) {
     // create a copy and assign some sane defaults
     options = Object.assign({}, {
         key: null,
-        strict: true,
         checkTime: true,
         timeWindow: 30,
         dataHeader: "X-Akamai-G2O-Auth-Data",
         signHeader: "X-Akamai-G2O-Auth-Sign",
         signString: defaultSignStringFunction,
         extraCheck: null,
-        unauthenticatedStatusCode: 401,
         onUnauthenticated: defaultOnUnauthenticatedFunction,
     }, options);
 
@@ -155,6 +140,13 @@ function defaultKeyFunction(req, data, callback) {
     callback(new Error("unknown nonce"));
 }
 
-function defaultOnUnauthenticatedFunction(req, callback) {
-    return callback();
+function defaultOnUnauthenticatedFunction(req, res, next) {
+    var statusCode = 401;
+    if (typeof res.status === "function") {
+        // Express has a status() helper function
+        res.status(statusCode);
+    } else {
+        res.statusCode = statusCode;
+    }
+    res.end();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-g2o",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Connect/Express/Restify middleware implementing Akamai signature header authentication (G2O).",
   "repository": {
     "type": "git",

--- a/test/middleware/samples.yaml
+++ b/test/middleware/samples.yaml
@@ -17,7 +17,6 @@ a data header must be present:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
     client:
         path: "/abc"
         version: 1
@@ -25,7 +24,7 @@ a data header must be present:
         key: "s3cr3tk3y"
         dataHeader: "X-Hidden-Auth-Data-To-Pretend-Its-Not-There"
     expect:
-        statusCode: 200
+        statusCode: 401
         body:
             authenticated: false
             message: "missing auth data header"
@@ -34,7 +33,6 @@ unsupported algorithms fail authentication:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
     client:
         path: "/abc"
         version: 42
@@ -42,7 +40,7 @@ unsupported algorithms fail authentication:
         nonce: "v1" 
         key: "s3cr3tk3y"
     expect:
-        statusCode: 200
+        statusCode: 401
         body:
             authenticated: false
             message: "unsupported algorithm"
@@ -51,7 +49,6 @@ a sign header must be present:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
     client:
         path: "/abc"
         version: 1
@@ -59,12 +56,12 @@ a sign header must be present:
         key: "s3cr3tk3y"
         signHeader: "X-Hidden-Auth-Sign-To-Pretend-Its-Not-There"
     expect:
-        statusCode: 200
+        statusCode: 401
         body:
             authenticated: false
             message: "missing sign header"
 
-an incorrect signature returns a 401 in strict mode:
+an incorrect signature returns a 401:
     server:
         key:
             v1: "s3cr3tk3y"
@@ -79,33 +76,17 @@ an incorrect signature returns a 401 in strict mode:
             authenticated: false
             message: "invalid signature"
 
-an incorrect signature returns a configured status code in strict mode:
-    server:
-        key:
-            v1: "s3cr3tk3y"
-        unauthenticatedStatusCode: 407
-    client:
-        path: "/abc"
-        version: 1
-        nonce: "v1" 
-        key: "wr0ngk3y"
-    expect:
-        statusCode: 407
-        body:
-            authenticated: false
-
 the client nonce must be known by the server:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
     client:
         path: "/abc"
         version: 1
         nonce: "v3" 
         key: "m0res3cr3tk3y"
     expect:
-        statusCode: 200
+        statusCode: 401
         body:
             authenticated: false
             message: "unknown nonce"
@@ -114,7 +95,6 @@ a timestamp outside the allowed window fails authentication:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
     client:
         path: "/abc"
         version: 1
@@ -122,7 +102,7 @@ a timestamp outside the allowed window fails authentication:
         key: "s3cr3tk3y"
         time: 343958400
     expect:
-        statusCode: 200
+        statusCode: 401
         body:
             authenticated: false
             message: "request time too far off"
@@ -131,7 +111,6 @@ the timeWindow parameter can be used to control the allowed time delta:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
         timeWindow: 9999999999
     client:
         path: "/abc"
@@ -148,7 +127,6 @@ an alternate data header can be used:
     server:
         key:
             v1: "s3cr3tk3y"
-        strict: false
         dataHeader: "X-Alternate-Auth-Data"
     client:
         path: "/abc"

--- a/test/middleware/samples.yaml
+++ b/test/middleware/samples.yaml
@@ -79,6 +79,21 @@ an incorrect signature returns a 401 in strict mode:
             authenticated: false
             message: "invalid signature"
 
+an incorrect signature returns a configured status code in strict mode:
+    server:
+        key:
+            v1: "s3cr3tk3y"
+        unauthenticatedStatusCode: 407
+    client:
+        path: "/abc"
+        version: 1
+        nonce: "v1" 
+        key: "wr0ngk3y"
+    expect:
+        statusCode: 407
+        body:
+            authenticated: false
+
 the client nonce must be known by the server:
     server:
         key:


### PR DESCRIPTION
We have a requirement to log out when the request is unauthorized, even when we do not have it in strict mode.

Currently `401` means something special to our app, so we configured ours to return `407` invalid proxy.

I am up for any suggestions on naming and implementation.